### PR TITLE
chore: update `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 </p>
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-![example branch parameter](https://github.com/cloudwalk/brlc-asset-liability/actions/workflows/build.yml/badge.svg?branch=main)
-![example branch parameter](https://github.com/cloudwalk/brlc-asset-liability/actions/workflows/test.yml/badge.svg?branch=main)
+![example branch parameter](https://github.com/cloudwalk/brlc-net-yield-distributor/actions/workflows/build.yml/badge.svg?branch=main)
+![example branch parameter](https://github.com/cloudwalk/brlc-net-yield-distributor/actions/workflows/test.yml/badge.svg?branch=main)
 
 This repository contains `NetYieldDistributor` smart contracts.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Assets, Liabilities and Yield smart contracts
+# Net Yield Distributor
 
 <p align="center">
   <img src="./docs/media/brlc-cover.png">


### PR DESCRIPTION
Fixes cloudwalk/product-smart-contracts#201

## Description
This PR contains changes related to this repository renaming from `brlc-asset-liability` to `brlc-net-yield-distributor`.